### PR TITLE
Make Wrap() and Seal() on nil return nil

### DIFF
--- a/skip/error.go
+++ b/skip/error.go
@@ -41,6 +41,9 @@ func Errorf(v Vice, skip uint, format string, a ...interface{}) error {
 //
 // This func is intended to be used for implementing APIs on top of vice.
 func Wrap(err error, v Vice, skip uint, text string) error {
+	if err == nil {
+		return nil
+	}
 	return wrapped(&wrapError{sealError{err: err, msg: text}}, v, skip)
 }
 
@@ -55,6 +58,9 @@ func Wrap(err error, v Vice, skip uint, text string) error {
 //
 // This func is intended to be used for implementing APIs on top of vice.
 func Wrapf(err error, v Vice, skip uint, format string, a ...interface{}) error {
+	if err == nil {
+		return nil
+	}
 	return wrapped(&wrapError{sealError{err: err, msg: fmt.Sprintf(format, a...)}}, v, skip)
 }
 
@@ -68,6 +74,9 @@ func Wrapf(err error, v Vice, skip uint, format string, a ...interface{}) error 
 //
 // This func is intended to be used for implementing APIs on top of vice.
 func Seal(err error, v Vice, skip uint, text string) error {
+	if err == nil {
+		return nil
+	}
 	return sealed(&sealError{err: err, msg: text}, v, skip)
 }
 
@@ -81,6 +90,9 @@ func Seal(err error, v Vice, skip uint, text string) error {
 //
 // This func is intended to be used for implementing APIs on top of vice.
 func Sealf(err error, v Vice, skip uint, format string, a ...interface{}) error {
+	if err == nil {
+		return nil
+	}
 	return sealed(&sealError{err: err, msg: fmt.Sprintf(format, a...)}, v, skip)
 }
 

--- a/vice_test.go
+++ b/vice_test.go
@@ -32,3 +32,20 @@ func TestVice(t *testing.T) {
 		}
 	}
 }
+
+func TestWrapNil(t *testing.T) {
+	inner := errors.New("no auth")
+	wrapped := Wrap(inner, AuthRequired, "wrapping")
+
+	if wrapped == nil {
+		t.Error("Wrapped error should not be nil")
+	}
+
+	maybeError := func() error {
+		return nil
+	}()
+	wrapped = Wrap(maybeError, Conflict, "try wrapping")
+	if wrapped != nil {
+		t.Error("Wrapping a nil error should return nil")
+	}
+}


### PR DESCRIPTION
This PR makes the behavior of `Wrap()` and `Seal()` conform to the documentation: when called with a `nil` inner error, should return `nil`.

Fixes #1 