### PR TITLE
Add NoVice checks.

### DIFF
--- a/is.go
+++ b/is.go
@@ -28,6 +28,8 @@ func Is(err error, v Vice) bool {
 		return isInternal(err)
 	case Canceled:
 		return isCanceled(err)
+	case NoVice:
+		return isNoVice(err)
 	default:
 		return false
 	}
@@ -119,4 +121,14 @@ func isCanceled(err error) bool {
 		return e.Canceled()
 	}
 	return false
+}
+
+func isNoVice(err error) bool {
+	for _, v := range vices {
+		if Is(err, v) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/vice.go
+++ b/vice.go
@@ -62,3 +62,19 @@ const (
 	// consumer.
 	Canceled
 )
+
+// vices is a fixed length slice of Vice verbs used to iterate over them
+// accordingly. It only contains actual vices, NoVice is not included.
+var vices = [...]Vice{
+	Timeout,
+	Temporary,
+	Closed,
+	AuthRequired,
+	AuthFailed,
+	Permission,
+	Conflict,
+	InvalidArgument,
+	NotFound,
+	Internal,
+	Canceled,
+}

--- a/vice_test.go
+++ b/vice_test.go
@@ -6,20 +6,6 @@ import (
 )
 
 func TestVice(t *testing.T) {
-	vices := []Vice{
-		Timeout,
-		Temporary,
-		Closed,
-		AuthRequired,
-		AuthFailed,
-		Permission,
-		Conflict,
-		InvalidArgument,
-		NotFound,
-		Internal,
-		Canceled,
-	}
-
 	for _, v := range vices {
 		err := New(v, "test")
 		if !Is(err, v) {
@@ -33,6 +19,27 @@ func TestVice(t *testing.T) {
 			t.Error("Did not create correct error form")
 		}
 	}
+}
+
+func TestNoVice(t *testing.T) {
+	t.Run("with Vice error", func(t *testing.T) {
+		for i, v := range vices {
+			err := New(v, "test")
+			if Is(err, NoVice) {
+				t.Errorf("%d element should be concrete Vice type", i)
+			}
+		}
+	})
+
+	t.Run("with NoVice error", func(t *testing.T) {
+		if !Is(errors.New("test"), NoVice) {
+			t.Errorf("Expected custom error to be NoVice")
+		}
+
+		if !Is(New(NoVice, "test"), NoVice) {
+			t.Errorf("Expected NoVice error to be NoVice")
+		}
+	})
 }
 
 func TestWrapNil(t *testing.T) {


### PR DESCRIPTION
This will allow us to properly validate that a test is of the NoVice
type.