### PR TITLE
Add Precondition error behaviour

### DIFF
--- a/is.go
+++ b/is.go
@@ -28,6 +28,8 @@ func Is(err error, v Vice) bool {
 		return isInternal(err)
 	case Canceled:
 		return isCanceled(err)
+	case PreconditionFailed:
+		return isPreconditionFailed(err)
 	case NoVice:
 		return isNoVice(err)
 	default:
@@ -119,6 +121,14 @@ func isCanceled(err error) bool {
 	var e interface{ Canceled() bool }
 	if xerrors.As(err, &e) {
 		return e.Canceled()
+	}
+	return false
+}
+
+func isPreconditionFailed(err error) bool {
+	var e interface{ PreconditionFailed() bool }
+	if xerrors.As(err, &e) {
+		return e.PreconditionFailed()
 	}
 	return false
 }

--- a/skip/error.go
+++ b/skip/error.go
@@ -121,6 +121,8 @@ func sealed(serr *sealError, v Vice, skip uint) error {
 		return &internalSeal{*serr}
 	case Canceled:
 		return &canceledSeal{*serr}
+	case PreconditionFailed:
+		return &preconditionFailedSeal{*serr}
 	default:
 		return serr
 	}
@@ -151,6 +153,8 @@ func wrapped(werr *wrapError, v Vice, skip uint) error {
 		return &internalWrap{*werr}
 	case Canceled:
 		return &canceledWrap{*werr}
+	case PreconditionFailed:
+		return &preconditionFailedWrap{*werr}
 	default:
 		return werr
 	}

--- a/skip/vice.go
+++ b/skip/vice.go
@@ -18,6 +18,7 @@ const (
 	NotFound
 	Internal
 	Canceled
+	PreconditionFailed
 )
 
 // implementations of all the error types
@@ -65,6 +66,10 @@ type canceledSeal struct{ sealError }
 
 func (canceledSeal) Canceled() bool { return true }
 
+type preconditionFailedSeal struct{ sealError }
+
+func (preconditionFailedSeal) PreconditionFailed() bool { return true }
+
 // wrapped implmentations of all the error types
 
 type timeoutWrap struct{ wrapError }
@@ -110,3 +115,7 @@ func (internalWrap) Internal() bool { return true }
 type canceledWrap struct{ wrapError }
 
 func (canceledWrap) Canceled() bool { return true }
+
+type preconditionFailedWrap struct{ wrapError }
+
+func (preconditionFailedWrap) PreconditionFailed() bool { return true }

--- a/vice.go
+++ b/vice.go
@@ -48,7 +48,9 @@ const (
 	// already exists.
 	Conflict
 
-	// InvalidArgument indicates the client provided bad input.
+	// InvalidArgument indicates the client provided bad input. This differs
+	// from PreconditionFailed as this is based on the given arguments rather
+	// than the state of the system. For example, an invalid HTTP scheme.
 	InvalidArgument
 
 	// NotFound indicates that a requested resource was not found.
@@ -61,6 +63,12 @@ const (
 	// Canceled means the operation has been canceled, typically by the
 	// consumer.
 	Canceled
+
+	// PreconditionFailed indicates that the state of the system does not meet the
+	// requirements to fulfull the request.
+	// For example, a directory to be deleted may be non-empty, an rmdir
+	// operation is applied to a non-directory, etc.
+	PreconditionFailed
 )
 
 // vices is a fixed length slice of Vice verbs used to iterate over them
@@ -77,4 +85,5 @@ var vices = [...]Vice{
 	NotFound,
 	Internal,
 	Canceled,
+	PreconditionFailed,
 }


### PR DESCRIPTION
This introduces the Precondition behaviour which can be used to indicate
that the underlying system is not in a state where it can process the
request.

It differs from an InvalidArgument, where the input data is not valid
rather than the system itself.