### PR TITLE
Implement ForError function

### DIFF
--- a/error.go
+++ b/error.go
@@ -57,3 +57,25 @@ func Seal(err error, v Vice, text string) error {
 func Sealf(err error, v Vice, format string, a ...interface{}) error {
 	return skip.Sealf(err, skip.Vice(v), 1, format, a...)
 }
+
+// ForError returns a wrapped vice type found for the given error.
+//
+// This loops over all types to determine if the the error wraps that type. This
+// means this function is not deterministic if multiple `Wrap()` calls have been
+// used on the given error. To make sure it is deterministic, use the `Seal()`
+// method.
+//
+// If the error is not wrapped or sealed with this package, it will return
+// NoVice.
+//
+// This can be useful for map lookups to map specific types to descriptive
+// messages.
+func ForError(err error) Vice {
+	for _, v := range vices {
+		if Is(err, v) {
+			return v
+		}
+	}
+
+	return NoVice
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,19 @@
+package vice
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestForError(t *testing.T) {
+	for _, v := range vices {
+		err := New(v, "test error")
+		if v != ForError(err) {
+			t.Fatalf("expected vice from error to equal error's specified vice")
+		}
+	}
+
+	if ForError(errors.New("non vice error")) != NoVice {
+		t.Fatalf("expected non vice error to return NoVice type")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/jbowes/vice
 
 go 1.12
 
-require golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522
+require golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
-golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
This adds a ForError function, allowing callers to get the vice type out
of an error when desired.

This can be useful for map lookups to map errors to specific messages.